### PR TITLE
Use 0 and 1 for boolean

### DIFF
--- a/lib/deserializers.js
+++ b/lib/deserializers.js
@@ -24,13 +24,12 @@ var deserializers = {
       throw new Error('Expected string to deserialize: ' + str);
     }
     var bool;
-    try {
-      bool = JSON.parse(dec(str));
-    } catch (err) {
-      // pass
-    }
-    if (typeof bool !== 'boolean') {
-      throw new Error('Expected boolean to deserialize: ' + str);
+    if (str === '1') {
+      bool = true;
+    } else if (str === '0') {
+      bool = false;
+    } else {
+      throw new Error('Expected "1" or "0" for boolean: ' + str);
     }
     return bool;
   },

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -19,7 +19,7 @@ var serializers = {
     if (typeof bool !== 'boolean') {
       throw new Error('Expected boolean to serialize: ' + bool);
     }
-    return enc(JSON.stringify(bool));
+    return bool ? '1' : '0';
   },
   date: function(date) {
     if (!util.isDate(date)) {

--- a/test/lib/deserializers.test.js
+++ b/test/lib/deserializers.test.js
@@ -79,8 +79,8 @@ experiment('deserializers', function() {
 
     test('returns an appropriate deserializer for boolean', function(done) {
       var deserialize = get('boolean');
-      assert.equal(deserialize('true'), true);
-      assert.equal(deserialize('false'), false);
+      assert.equal(deserialize('1'), true);
+      assert.equal(deserialize('0'), false);
       done();
     });
 
@@ -88,7 +88,7 @@ experiment('deserializers', function() {
       var deserialize = get('boolean');
       assert.throws(function() {
         deserialize('foo');
-      }, 'Expected boolean to deserialize: ');
+      }, 'Expected "1" or "0" for boolean: ');
       done();
     });
 

--- a/test/lib/serializers.test.js
+++ b/test/lib/serializers.test.js
@@ -57,8 +57,8 @@ experiment('serializers', function() {
 
     test('returns an appropriate serializer for boolean', function(done) {
       var serialize = get('boolean');
-      assert.equal(serialize(true), 'true');
-      assert.equal(serialize(false), 'false');
+      assert.equal(serialize(true), '1');
+      assert.equal(serialize(false), '0');
       done();
     });
 


### PR DESCRIPTION
Instead of serializing as "true" and "false", this serializes booleans as "0" and "1".