### PR TITLE
Allow providers to be unregistered

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,14 @@ exports.register = function(config, callback) {
   return store.register(config, callback);
 };
 
+/**
+ * Unregister an existing state provider.
+ * @param {function(Object)} callback Callback registered by the provider.
+ */
+exports.unregister = function(callback) {
+  return store.unregister(callback);
+};
+
 setTimeout(function() {
   updateStore();
 });

--- a/lib/store.js
+++ b/lib/store.js
@@ -16,6 +16,12 @@ var Store = exports.Store = function(callback) {
 };
 
 
+Store.prototype.unregister = function(callback) {
+  this._providers = this._providers.filter(function(provider) {
+    return provider.callback !== callback;
+  });
+};
+
 /**
  * Register a new state provider.
  * @param {Object} config Schema config.
@@ -40,10 +46,15 @@ Store.prototype.register = function(config, callback) {
 
   this._providers.push(provider);
   setTimeout(function() {
-    this._notifyProvider(provider);
+    if (this._providers.indexOf(provider) > -1) {
+      this._notifyProvider(provider);
+    }
   }.bind(this), 0);
 
   return function update(state) {
+    if (this._providers.indexOf(provider) === -1) {
+      throw new Error('Unregistered provider attempting to update state');
+    }
     if (arguments.length === 2) {
       var args = Array.prototype.slice.call(arguments, 0);
       state = {};

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ If you're using a non-CommonJS module loader or just plain `<script>` tags, the 
 
 ### `hashed.register`
 
-The `hashed` module exports a single `register` function that is to be called by components that want to initialize their state by deserializing values from the URL hash or persist their state by serializing values to the URL hash.  Multiple components (that may not know about one another) can register for "slots" in the hash.
+The `hashed` module exports a `register` function that is to be called by components that want to initialize their state by deserializing values from the URL hash or persist their state by serializing values to the URL hash.  Multiple components (that may not know about one another) can register for "slots" in the hash.
 
 The `register` function takes two arguments:
 
@@ -34,6 +34,11 @@ The `register` function returns a function:
 
  * `function(Object)` A function that should be called whenever a component's state changes.  The URL hash will be updated with serialized versions of the state values.
 
+### `hashed.unregister`
+
+The `unregister` function is to stop synchronizing state with the URL hash.  It should be called with the same `listener` function passed to the `register` function.
+
+
 ## Example
 
 ```js
@@ -43,16 +48,23 @@ var config = {
   numberValue: 42
 };
 
-var update = hashed.register(config, function(hash) {
+function listener(hash) {
   // called when the URL hash is updated
   // the hash object includes any changed values
-});
+}
+
+// register your listener for hash changes
+var update = hashed.register(config, listener);
 
 // call the update function when you want to have the URL hash
 // updated with some new state
 update({
   stringValue: 'bar'
 });
+
+// unregister when you no longer want to be notified of changes
+hashed.unregister(listener);
+
 ```
 
 [![Current Status](https://secure.travis-ci.org/tschaub/hashed.png?branch=master)](https://travis-ci.org/tschaub/hashed)

--- a/test/lib/store.test.js
+++ b/test/lib/store.test.js
@@ -18,6 +18,48 @@ lab.experiment('store', function() {
 
     });
 
+    lab.experiment('#unregister()', function() {
+
+      lab.test('allows a provider to be removed', function(done) {
+        var store = new Store(noop);
+
+        var calls = [];
+        var callback = function(changes) {
+          calls.push(changes);
+        };
+        store.register({foo: 'bar'}, callback);
+
+        store.unregister(callback);
+        store.update({foo: 'bam'});
+
+        setTimeout(function() {
+          expect(calls).to.have.length(0);
+          done();
+        }, 0);
+      });
+
+      lab.test('causes unregistered provider update to throw', function(done) {
+        var store = new Store(noop);
+
+        var calls = [];
+        var callback = function(changes) {
+          calls.push(changes);
+        };
+        var update = store.register({foo: 'bar'}, callback);
+
+        store.unregister(callback);
+
+        var call = function() {
+          update({foo: 'bam'});
+        };
+        expect(call).to.throw(
+            'Unregistered provider attempting to update state');
+        done();
+
+      });
+
+    });
+
     lab.experiment('#register()', function() {
 
       lab.test('registers a new provider', function(done) {


### PR DESCRIPTION
Unregister a provider with `hashed.unregister(callback)`.