### PR TITLE
Delay and debounce callback calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,13 +2,16 @@ var Store = require('./store').Store;
 var util = require('./util');
 
 function updateHash(values) {
-  location.hash = '#/' + util.zip(values).join('/');
+  var parts = util.zip(values);
+  if (parts.length > 0) {
+    location.hash = '#/' + parts.join('/');
+  }
 }
 
 var store = new Store(updateHash);
 
 function updateStore() {
-  var zipped = location.hash.length > 1 ?
+  var zipped = location.hash.length > 2 ?
       location.hash.substring(2).split('/') : [];
   store.update(util.unzip(zipped));
 }

--- a/lib/store.js
+++ b/lib/store.js
@@ -13,8 +13,20 @@ var Store = exports.Store = function(callback) {
   this._values = {};
   this._providers = [];
   this._callback = callback;
+  this._callbackTimer = null;
 };
 
+Store.prototype._scheduleCallback = function() {
+  if (this._callbackTimer) {
+    clearTimeout(this._callbackTimer);
+  }
+  this._callbackTimer = setTimeout(this._debouncedCallback.bind(this));
+};
+
+Store.prototype._debouncedCallback = function() {
+  this._callbackTimer = null;
+  this._callback(this._values);
+};
 
 Store.prototype.unregister = function(callback) {
   this._providers = this._providers.filter(function(provider) {
@@ -68,7 +80,7 @@ Store.prototype.register = function(config, callback) {
     }
     util.extend(provider.state, state);
     util.extend(this._values, serialized);
-    this._callback(this._values);
+    this._scheduleCallback();
   }.bind(this);
 };
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -67,11 +67,6 @@ Store.prototype.register = function(config, callback) {
     if (this._providers.indexOf(provider) === -1) {
       throw new Error('Unregistered provider attempting to update state');
     }
-    if (arguments.length === 2) {
-      var args = Array.prototype.slice.call(arguments, 0);
-      state = {};
-      state[args[0]] = args[1];
-    }
     var serialized = {};
     var schema = provider.schema;
     for (var key in state) {

--- a/test/lib/store.test.js
+++ b/test/lib/store.test.js
@@ -94,23 +94,6 @@ lab.experiment('store', function() {
         }, 5);
       });
 
-      lab.test('calls callback asynchronously on update', function(done) {
-        var calls = [];
-        var store = new Store(function(values) {
-          calls.push(values);
-        });
-
-        var update = store.register({foo: 'bar'}, noop);
-
-        // accepts key, value style
-        update('foo', 'baz');
-        setTimeout(function() {
-          expect(calls).to.have.length(1);
-          expect(calls[0]).to.deep.equal({foo: 'baz'});
-          done();
-        }, 5);
-      });
-
       lab.test('debounces callback calls', function(done) {
         var calls = [];
         var store = new Store(function(values) {

--- a/test/lib/store.test.js
+++ b/test/lib/store.test.js
@@ -69,25 +69,64 @@ lab.experiment('store', function() {
       });
 
       lab.test('returns a function used to update state', function(done) {
+        var store = new Store(noop);
+        var update = store.register({foo: 'bar'}, noop);
+
+        expect(update).to.be.a.function();
+        done();
+      });
+
+      lab.test('calls callback asynchronously on update', function(done) {
         var calls = [];
         var store = new Store(function(values) {
           calls.push(values);
         });
-        var update = store.register({foo: 'bar'}, noop);
 
-        expect(update).to.be.a.function();
+        var update = store.register({foo: 'bar'}, noop);
 
         // accepts state object
         update({foo: 'bam'});
-        expect(calls).to.have.length(1);
-        expect(calls[0]).to.deep.equal({foo: 'bam'});
+        setTimeout(function() {
+          expect(calls).to.have.length(1);
+          expect(calls[0]).to.deep.equal({foo: 'bam'});
+
+          done();
+        }, 5);
+      });
+
+      lab.test('calls callback asynchronously on update', function(done) {
+        var calls = [];
+        var store = new Store(function(values) {
+          calls.push(values);
+        });
+
+        var update = store.register({foo: 'bar'}, noop);
 
         // accepts key, value style
         update('foo', 'baz');
-        expect(calls).to.have.length(2);
-        expect(calls[1]).to.deep.equal({foo: 'baz'});
+        setTimeout(function() {
+          expect(calls).to.have.length(1);
+          expect(calls[0]).to.deep.equal({foo: 'baz'});
+          done();
+        }, 5);
+      });
 
-        done();
+      lab.test('debounces callback calls', function(done) {
+        var calls = [];
+        var store = new Store(function(values) {
+          calls.push(values);
+        });
+
+        var update = store.register({foo: 'bar'}, noop);
+
+        update({foo: 'bam'});
+        update({foo: 'baz'});
+
+        setTimeout(function() {
+          expect(calls).to.have.length(1);
+          expect(calls[0]).to.deep.equal({foo: 'baz'});
+          done();
+        }, 5);
       });
 
       lab.test('throws when registering with a conflicting key', function(done) {


### PR DESCRIPTION
This makes it possible for a provider to call the returned update function before hash has been deserialized.  Calls to the hash updating callback will be queued and debounced.
