### PR TITLE
Only call store.update() on significant hashchange events

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,0 +1,56 @@
+var util = require('./util');
+
+/**
+ * A lookup of updates to the hash as a result of store updates.  If a
+ * hashchange event corresponds to one of these members, the store will not
+ * be updated, and the member will be deleted.
+ * @type {Object}
+ */
+var updates = {};
+
+/**
+ * Called when the store is updated.
+ * @param {Object} values Store values by key.
+ * @param {Object} loc The location object whose hash property will be set.
+ */
+function updateHash(values, loc) {
+  var parts = util.zip(values);
+  if (parts.length > 0) {
+    var path = parts.join('/');
+    updates[path] = true;
+    loc.hash = '#/' + path;
+  }
+}
+
+/**
+ * Update the store with values from the hash.
+ * @param {Object} loc The location with hash values for the store.
+ * @param {Store} store The store.
+ */
+function updateStore(loc, store) {
+  var zipped;
+  if (loc.hash.length > 2) {
+    var path = loc.hash.substring(2);
+    if (updates[path]) {
+      delete updates[path];
+      return;
+    }
+    zipped = path.split('/');
+  } else {
+    zipped = [];
+  }
+  store.update(util.unzip(zipped));
+}
+
+/**
+ * Reset the updates cache.
+ */
+function reset() {
+  for (var key in updates) {
+    delete updates[key];
+  }
+}
+
+exports.reset = reset;
+exports.updateHash = updateHash;
+exports.updateStore = updateStore;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,41 @@
 var Store = require('./store').Store;
 var util = require('./util');
 
+/**
+ * A lookup of updates to the hash as a result of store updates.  If a
+ * hashchange event corresponds to one of these members, the store will not
+ * be updated, and the member will be deleted.
+ * @type {Object}
+ */
+var updates = {};
+
+/**
+ * Called when the store is updated.
+ * @param {Object} values Store values by key.
+ */
 function updateHash(values) {
   var parts = util.zip(values);
   if (parts.length > 0) {
-    location.hash = '#/' + parts.join('/');
+    var path = parts.join('/');
+    updates[path] = true;
+    location.hash = '#/' + path;
   }
 }
 
 var store = new Store(updateHash);
 
 function updateStore() {
-  var zipped = location.hash.length > 2 ?
-      location.hash.substring(2).split('/') : [];
+  var zipped;
+  if (location.hash.length > 2) {
+    var path = location.hash.substring(2);
+    if (updates[path]) {
+      delete updates[path];
+      return;
+    }
+    zipped = path.split('/');
+  } else {
+    zipped = [];
+  }
   store.update(util.unzip(zipped));
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,43 +1,9 @@
 var Store = require('./store').Store;
-var util = require('./util');
+var hash = require('./hash');
 
-/**
- * A lookup of updates to the hash as a result of store updates.  If a
- * hashchange event corresponds to one of these members, the store will not
- * be updated, and the member will be deleted.
- * @type {Object}
- */
-var updates = {};
-
-/**
- * Called when the store is updated.
- * @param {Object} values Store values by key.
- */
-function updateHash(values) {
-  var parts = util.zip(values);
-  if (parts.length > 0) {
-    var path = parts.join('/');
-    updates[path] = true;
-    location.hash = '#/' + path;
-  }
-}
-
-var store = new Store(updateHash);
-
-function updateStore() {
-  var zipped;
-  if (location.hash.length > 2) {
-    var path = location.hash.substring(2);
-    if (updates[path]) {
-      delete updates[path];
-      return;
-    }
-    zipped = path.split('/');
-  } else {
-    zipped = [];
-  }
-  store.update(util.unzip(zipped));
-}
+var store = new Store(function(values) {
+  hash.updateHash(values, location);
+});
 
 /**
  * Register a new state provider.
@@ -57,8 +23,16 @@ exports.unregister = function(callback) {
   return store.unregister(callback);
 };
 
-setTimeout(function() {
-  updateStore();
-});
+function updateStore() {
+  hash.updateStore(location, store);
+}
 
+/**
+ * Kick things off by updating the store with values from the hash.
+ */
+setTimeout(updateStore);
+
+/**
+ * Update the store any time the hash changes.
+ */
 addEventListener('hashchange', updateStore);

--- a/test/lib/hash.test.js
+++ b/test/lib/hash.test.js
@@ -1,0 +1,122 @@
+var lab = exports.lab = require('lab').script();
+var expect = require('code').expect;
+
+var Store = require('../../lib/store').Store;
+var hash = require('../../lib/hash');
+
+lab.experiment('hash', function() {
+
+  lab.afterEach(function(done) {
+    hash.reset();
+    done();
+  });
+
+  lab.experiment('updateHash()', function() {
+
+    lab.test('serializes values for the hash', function(done) {
+      var values = {
+        foo: 'bar',
+        num: '42'
+      };
+      var loc = {};
+      hash.updateHash(values, loc);
+      expect(loc.hash).to.equal('#/foo/bar/num/42');
+      done();
+    });
+
+    lab.test('does nothing for an empty object', function(done) {
+      var values = {};
+      var loc = {};
+      hash.updateHash(values, loc);
+      expect(loc.hash).to.be.undefined();
+      done();
+    });
+
+  });
+
+  lab.experiment('updateStore()', function() {
+    var noop = function() {};
+
+    lab.test('calls store.update() with values from the hash', function(done) {
+      var log = [];
+      var store = new Store(noop);
+      store.update = function() {
+        log.push(arguments);
+      };
+
+      var loc = {
+        hash: '#/foo/bar/num/42'
+      };
+
+      hash.updateStore(loc, store);
+      expect(log).to.have.length(1);
+      var args = log[0];
+      expect(args).to.have.length(1);
+      expect(args[0]).to.deep.equal({
+        foo: 'bar',
+        num: '42'
+      });
+      done();
+    });
+
+    lab.test('calls update with an empty object for no hash', function(done) {
+      var log = [];
+      var store = new Store(noop);
+      store.update = function() {
+        log.push(arguments);
+      };
+
+      var loc = {
+        hash: ''
+      };
+
+      hash.updateStore(loc, store);
+      expect(log).to.have.length(1);
+      var args = log[0];
+      expect(args).to.have.length(1);
+      expect(Object.keys(args[0])).to.have.length(0);
+      done();
+    });
+
+    lab.test('does not call store.update() for values from updateHash()', function(done) {
+      var log = [];
+      var store = new Store(noop);
+      store.update = function() {
+        log.push(arguments);
+      };
+
+      var loc = {};
+
+      hash.updateHash({foo: 'bar'}, loc);
+      hash.updateStore(loc, store);
+
+      expect(log).to.have.length(0);
+      done();
+    });
+
+    lab.test('only calls store.update() for externally changed values', function(done) {
+      var log = [];
+      var store = new Store(noop);
+      store.update = function() {
+        log.push(arguments);
+      };
+
+
+      hash.updateHash({foo: 'bar'}, {});
+      hash.updateHash({num: 42}, {});
+
+      hash.updateStore({hash: '#/foo/bar'}, store);
+      expect(log).to.have.length(0);
+
+      hash.updateStore({hash: '#/num/42'}, store);
+      expect(log).to.have.length(0);
+
+      hash.updateStore({hash: '#/baz/bam'}, store);
+      expect(log).to.have.length(1);
+      expect(log[0][0]).to.deep.equal({baz: 'bam'});
+      done();
+    });
+
+  });
+
+});


### PR DESCRIPTION
Currently, on every `hashchange`, the store reconciles it's state with it's providers' state, and notifies each provider where there is a difference.  This causes problems when `hashchange` events come in after multiple providers have state changes.

```js
// original hash: #/foo/bam/num/10
// provider 1 notifies of state changes
updateHashForProvider1({foo: 'bar'});
// ... some time passes ...
// provider2 notifies of state changes
updateHashForProvider2({num: 42});
// ... some time passes ...
// hashchange event for 1st change: #/foo/bar/num/10
// we think provider 2 needs notification
callbackForProvider2({num: 10});
// depending on what this callback does, it may trigger updateHashForProvider2({num: 10})
// hashchange event for 2nd change: #/foo/bar/num/42
// we think provider 2 needs notification
callbackForProvider2({num: 42});
// this can go on forever
```

This change makes it so `hashchange` events that correspond to changes that the library itself has made will be ignored.  So the only changes that the providers get notified about should be user generated (or otherwise outside this library).
