### PR TITLE
Allow consumers to pluck portions of the hash

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -43,6 +43,24 @@ function updateStore(loc, store) {
 }
 
 /**
+ * Generate a URL hash that is a subset of the provided location hash.
+ * @param {Object} loc The location object.
+ * @param {Array.<string>} keys The list of keys to be plucked from the hash.
+ * @return {string} A hash string that includes key/value pairs for just the
+ *     provided set of keys.
+ */
+function pluck(loc, keys) {
+  var values = util.unzip(loc.hash.substring(2).split('/'));
+  var plucked = {};
+  for (var i = 0, ii = keys.length; i < ii; ++i) {
+    if (keys[i] in values) {
+      plucked[keys[i]] = values[keys[i]];
+    }
+  }
+  return '#/' + util.zip(plucked).join('/');
+}
+
+/**
  * Reset the updates cache.
  */
 function reset() {
@@ -51,6 +69,7 @@ function reset() {
   }
 }
 
+exports.pluck = pluck;
 exports.reset = reset;
 exports.updateHash = updateHash;
 exports.updateStore = updateStore;

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,15 @@ exports.unregister = function(callback) {
   store.unregister(callback);
 };
 
+/**
+ * Get a URL hash given a set of keys.
+ * @param {Array.<string>} keys The keys of interest.
+ * @return {string} A URL hash with just the key/value pairs of interest.
+ */
+exports.pluck = function(keys) {
+  return hash.pluck(location, keys);
+};
+
 function updateStore() {
   hash.updateStore(location, store);
 }

--- a/test/lib/hash.test.js
+++ b/test/lib/hash.test.js
@@ -11,6 +11,28 @@ lab.experiment('hash', function() {
     done();
   });
 
+  lab.experiment('pluck()', function() {
+
+    lab.test('returns a subset of key/value pairs from a hash', function(done) {
+      var loc = {
+        hash: '#/foo/bar/num/42/bam/chicken'
+      };
+
+      expect(hash.pluck(loc, ['foo', 'bam'])).to.equal('#/foo/bar/bam/chicken');
+      done();
+    });
+
+    lab.test('silently disregards missing values', function(done) {
+      var loc = {
+        hash: '#/foo/bar/num/42'
+      };
+
+      expect(hash.pluck(loc, ['foo', 'bam'])).to.equal('#/foo/bar');
+      done();
+    });
+
+  });
+
   lab.experiment('updateHash()', function() {
 
     lab.test('serializes values for the hash', function(done) {


### PR DESCRIPTION
Given `location.hash = '#/foo/bar/num/42/chicken/soup'`, consumers can call `hashed.pluck(['foo', 'chicken'])` to get `'#/foo/bar/chicken/soup'`.
