### PR TITLE
Breaking changes for 2.0.0

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -46,18 +46,18 @@
             item: 'beans'
           };
 
-          var update = hashed.register(config, function(state) {
-            // called whenever the state changes
-            for (var name in state) {
-              elements.namedItem(name).value = state[name];
+          var update = hashed.register(config, function(values) {
+            // called with initial values
+            for (var name in values) {
+              elements.namedItem(name).value = values[name];
             }
           });
 
           for (var name in config) {
             elements.namedItem(name).addEventListener('change', function(evt) {
-              var state = {};
-              state[evt.target.getAttribute('name')] = evt.target.value;
-              update(state);
+              var values = {};
+              values[evt.target.getAttribute('name')] = evt.target.value;
+              update(values);
             });
           }
 
@@ -89,18 +89,18 @@
             color: '#bada55'
           };
 
-          var update = hashed.register(config, function(state) {
-            // called whenever the state changes
-            for (var name in state) {
-              elements.namedItem(name).value = state[name];
+          var update = hashed.register(config, function(values) {
+            // called with initial values
+            for (var name in values) {
+              elements.namedItem(name).value = values[name];
             }
           });
 
           for (var name in config) {
             elements.namedItem(name).addEventListener('change', function(evt) {
-              var state = {};
-              state[evt.target.getAttribute('name')] = evt.target.value;
-              update(state);
+              var values = {};
+              values[evt.target.getAttribute('name')] = evt.target.value;
+              update(values);
             });
           }
 
@@ -132,19 +132,19 @@
             _: 'view-3'
           };
 
-          var update = hashed.register(config, function(state) {
-            // called whenever the state changes
-            for (var name in state) {
-              elements.namedItem(name).value = state[name];
+          var update = hashed.register(config, function(values) {
+            // called with initial values
+            for (var name in values) {
+              elements.namedItem(name).value = values[name];
             }
           });
 
           for (var name in config) {
             if (name !== '_') {
               elements.namedItem(name).addEventListener('change', function(evt) {
-                var state = {};
-                state[evt.target.getAttribute('name')] = evt.target.value;
-                update(state);
+                var values = {};
+                values[evt.target.getAttribute('name')] = evt.target.value;
+                update(values);
               });
             }
           }

--- a/lib/field.js
+++ b/lib/field.js
@@ -4,30 +4,24 @@ var serializers = require('./serializers');
 var deserializers = require('./deserializers');
 
 /**
- * Create a new field.  A field must have a default value (`init`) and is
+ * Create a new field.  A field must have a default value (`default`) and is
  * capable of serializing and deserializing values.
- * @param {Object} config Field configuration.  Must have an init property
- *     with a default value.  The init property can also be a function that
- *     returns the default value.  May have optional `serialize` and
- *     `deserialize` functions.  As a shorthand for providing a config object
- *     with an `init` property, a default value may be provided directly.
+ * @param {Object} config Field configuration.  Must have a `default` property
+ *     with a default value.  May have optional `serialize` and `deserialize`
+ *     functions.  As a shorthand for providing a config object with a `default`
+ *     property, a default value may be provided directly.
  * @constructor
  */
 exports.Field = function(config) {
   if (util.typeOf(config) !== 'object') {
-    config = {init: config};
+    this.default = config;
+  } else if (!('default' in config)) {
+    throw new Error('Missing default');
+  } else {
+    this.default = config.default;
   }
-  if (!('init' in config)) {
-    throw new Error('Missing init');
-  }
-  var init = config.init;
-  if (typeof init === 'function') {
-    init = init();
-  }
-  this.init = init;
 
-  var type = util.typeOf(init);
+  var type = util.typeOf(this.default);
   this.serialize = config.serialize || serializers.get(type);
   this.deserialize = config.deserialize || deserializers.get(type);
 };
-

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -6,11 +6,7 @@ var util = require('./util');
  * @param {Object} loc The location object whose hash property will be set.
  */
 function set(values, loc) {
-  var parts = util.zip(values);
-  if (parts.length > 0) {
-    var path = parts.join('/');
-    loc.hash = '#/' + path;
-  }
+  loc.hash = serialize(values);
 }
 
 /**
@@ -29,5 +25,20 @@ function get(loc) {
   return util.unzip(zipped);
 }
 
+/**
+ * Serialize values for the hash.
+ * @param {Object} values The values to serialize.
+ * @return {string} The hash string.
+ */
+function serialize(values) {
+  var path = '';
+  var parts = util.zip(values);
+  if (parts.length > 0) {
+    path = '#/' + parts.join('/');
+  }
+  return path;
+}
+
 exports.get = get;
 exports.set = set;
+exports.serialize = serialize;

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,75 +1,33 @@
 var util = require('./util');
 
 /**
- * A lookup of updates to the hash as a result of store updates.  If a
- * hashchange event corresponds to one of these members, the store will not
- * be updated, and the member will be deleted.
- * @type {Object}
- */
-var updates = {};
-
-/**
- * Called when the store is updated.
- * @param {Object} values Store values by key.
+ * Update the hash with the provided string values.
+ * @param {Object} values String values by key.
  * @param {Object} loc The location object whose hash property will be set.
  */
-function updateHash(values, loc) {
+function set(values, loc) {
   var parts = util.zip(values);
   if (parts.length > 0) {
     var path = parts.join('/');
-    updates[path] = true;
     loc.hash = '#/' + path;
   }
 }
 
 /**
- * Update the store with values from the hash.
- * @param {Object} loc The location with hash values for the store.
- * @param {Store} store The store.
+ * Get the current string values.
+ * @param {Object} loc The location with hash values.
+ * @return {Object} The string values.
  */
-function updateStore(loc, store) {
+function get(loc) {
   var zipped;
   if (loc.hash.length > 2) {
     var path = loc.hash.substring(2);
-    if (updates[path]) {
-      delete updates[path];
-      return;
-    }
     zipped = path.split('/');
   } else {
     zipped = [];
   }
-  store.update(util.unzip(zipped));
+  return util.unzip(zipped);
 }
 
-/**
- * Generate a URL hash that is a subset of the provided location hash.
- * @param {Object} loc The location object.
- * @param {Array.<string>} keys The list of keys to be plucked from the hash.
- * @return {string} A hash string that includes key/value pairs for just the
- *     provided set of keys.
- */
-function pluck(loc, keys) {
-  var values = util.unzip(loc.hash.substring(2).split('/'));
-  var plucked = {};
-  for (var i = 0, ii = keys.length; i < ii; ++i) {
-    if (keys[i] in values) {
-      plucked[keys[i]] = values[keys[i]];
-    }
-  }
-  return '#/' + util.zip(plucked).join('/');
-}
-
-/**
- * Reset the updates cache.
- */
-function reset() {
-  for (var key in updates) {
-    delete updates[key];
-  }
-}
-
-exports.pluck = pluck;
-exports.reset = reset;
-exports.updateHash = updateHash;
-exports.updateStore = updateStore;
+exports.get = get;
+exports.set = set;

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,3 +22,12 @@ exports.register = function(config, callback) {
 exports.unregister = function(callback) {
   store.unregister(callback);
 };
+
+/**
+ * Serialize values as they would be represented in the hash.
+ * @param {Object} values An object with values to be serialized.
+ * @return {string} The values as they would be represented in the hash.
+ */
+exports.serialize = function(values) {
+  hash.serialize(store.serialize(values));
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,14 @@
 var Store = require('./store').Store;
 var hash = require('./hash');
 
-var store = new Store(function(values) {
-  hash.updateHash(values, location);
+var store = new Store(hash.get(location), function(values) {
+  hash.set(values, location);
 });
 
 /**
  * Register a new state provider.
  * @param {Object} config Schema config.
- * @param {function(Object)} callback Called when the URL hash changes.
+ * @param {function(Object)} callback Called immediately with initial state.
  * @return {function(Object)} Call this function with any updates to the state.
  */
 exports.register = function(config, callback) {
@@ -22,26 +22,3 @@ exports.register = function(config, callback) {
 exports.unregister = function(callback) {
   store.unregister(callback);
 };
-
-/**
- * Get a URL hash given a set of keys.
- * @param {Array.<string>} keys The keys of interest.
- * @return {string} A URL hash with just the key/value pairs of interest.
- */
-exports.pluck = function(keys) {
-  return hash.pluck(location, keys);
-};
-
-function updateStore() {
-  hash.updateStore(location, store);
-}
-
-/**
- * Kick things off by updating the store with values from the hash.
- */
-setTimeout(updateStore);
-
-/**
- * Update the store any time the hash changes.
- */
-addEventListener('hashchange', updateStore);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,5 +1,4 @@
 var Field = require('./field').Field;
-var util = require('./util');
 
 
 /**
@@ -8,7 +7,7 @@ var util = require('./util');
  * @constructor
  */
 var Schema = exports.Schema = function(config) {
-  config = util.extend({}, config);
+  config = Object.assign({}, config);
   var fields = {};
   var prefix;
   if ('_' in config) {
@@ -54,8 +53,7 @@ Schema.prototype.forEachKey = function(callback, thisArg) {
  * Serialize a value.
  * @param {string} key The key or field name.
  * @param {*} value The value to serialize.
- * @param {Object} values Additional values for providers to use when
- *     serializing.
+ * @param {Object} values Additional values for providers to use when serializing.
  * @return {string} The serialized value.
  */
 Schema.prototype.serialize = function(key, value, values) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -87,7 +87,7 @@ Schema.prototype.getDefault = function(key) {
   if (!(key in this._fields)) {
     throw new Error('Unknown key: ' + key);
   }
-  return this._fields[key].init;
+  return this._fields[key].default;
 };
 
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -86,11 +86,21 @@ Store.prototype.register = function(config, callback) {
     }
     var serialized = {};
     var schema = provider.schema;
+    var changed = false;
+    var values = this._values;
     schema.forEachKey(function(key, prefixed) {
-      serialized[prefixed] = schema.serialize(key, state[key], state);
+      if (key in state) {
+        var serializedValue = schema.serialize(key, state[key], state);
+        if (values[prefixed] !== serializedValue) {
+          changed = true;
+          serialized[prefixed] = serializedValue;
+        }
+      }
     });
-    Object.assign(this._values, serialized);
-    this._scheduleCallback();
+    if (changed) {
+      Object.assign(this._values, serialized);
+      this._scheduleCallback();
+    }
   }.bind(this);
 };
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,16 +1,16 @@
 var Schema = require('./schema').Schema;
-var util = require('./util');
 
 
 /**
  * An object backed store of string values.  Allows registering multiple state
  * providers.
+ * @param {Object} values Initial serialized values.
  * @param {function(Object)} callback Called with an object of serialized
  *     values whenever a provider updates state.
  * @constructor
  */
-var Store = exports.Store = function(callback) {
-  this._values = {};
+var Store = exports.Store = function(values, callback) {
+  this._values = values;
   this._providers = [];
   this._callback = callback;
   this._callbackTimer = null;
@@ -28,10 +28,29 @@ Store.prototype._debouncedCallback = function() {
   this._callback(this._values);
 };
 
+/**
+ * Unregister a provider.  Deletes the provider's values from the underlying
+ * store and calls the store's callback.
+ * @param {Function} callback The provider's callback.
+ */
 Store.prototype.unregister = function(callback) {
+  var removedProvider;
   this._providers = this._providers.filter(function(provider) {
-    return provider.callback !== callback;
+    var remove = provider.callback === callback;
+    if (remove) {
+      removedProvider = provider;
+    }
+    return !remove;
   });
+  if (!removedProvider) {
+    throw new Error('Unable to unregister hashed state provider');
+  }
+  var values = this._values;
+  removedProvider.schema.forEachKey(function(key, prefixed) {
+    delete values[prefixed];
+  });
+  this._values = values;
+  this._scheduleCallback();
 };
 
 /**
@@ -43,7 +62,6 @@ Store.prototype.unregister = function(callback) {
 Store.prototype.register = function(config, callback) {
   var provider = {
     schema: new Schema(config),
-    state: {},
     callback: callback
   };
 
@@ -54,14 +72,13 @@ Store.prototype.register = function(config, callback) {
       throw new Error('Provider already registered using the same name: ' +
           conflicts);
     }
+    if (provider.callback === this._providers[i].callback) {
+      throw new Error('Provider already registered with the same callback');
+    }
   }
 
   this._providers.push(provider);
-  setTimeout(function() {
-    if (this._providers.indexOf(provider) > -1) {
-      this._notifyProvider(provider);
-    }
-  }.bind(this), 0);
+  this._initializeProvider(provider);
 
   return function update(state) {
     if (this._providers.indexOf(provider) === -1) {
@@ -69,78 +86,34 @@ Store.prototype.register = function(config, callback) {
     }
     var serialized = {};
     var schema = provider.schema;
-    for (var key in state) {
-      serialized[schema.getPrefixed(key)] =
-          schema.serialize(key, state[key], state);
-    }
-    util.extend(provider.state, state);
-    util.extend(this._values, serialized);
+    schema.forEachKey(function(key, prefixed) {
+      serialized[prefixed] = schema.serialize(key, state[key], state);
+    });
+    Object.assign(this._values, serialized);
     this._scheduleCallback();
   }.bind(this);
 };
 
 
 /**
- * Notify provider of stored state values where they differ from provider
- * state values.
- * @param {Object} provider Provider to be notified.
+ * Call provider with initial values.
+ * @param {Object} provider Provider to be initialized.
  */
-Store.prototype._notifyProvider = function(provider) {
+Store.prototype._initializeProvider = function(provider) {
   var state = {};
-  var changed = false;
+  var values = this._values;
   provider.schema.forEachKey(function(key, prefixed) {
     var deserializedValue;
-    if (prefixed in this._values) {
+    if (prefixed in values) {
       try {
-        deserializedValue =
-            provider.schema.deserialize(key, this._values[prefixed]);
+        deserializedValue = provider.schema.deserialize(key, values[prefixed]);
       } catch (err) {
         deserializedValue = provider.schema.getDefault(key);
       }
     } else {
       deserializedValue = provider.schema.getDefault(key);
     }
-    if (key in provider.state) {
-      // compare to current provider state
-      var serializedValue = provider.schema.serialize(key, deserializedValue,
-          provider.state);
-      var providerValue = provider.schema.serialize(key, provider.state[key],
-          provider.state);
-      if (serializedValue !== providerValue) {
-        state[key] = deserializedValue;
-        provider.state[key] = deserializedValue;
-        changed = true;
-      }
-    } else {
-      state[key] = deserializedValue;
-      provider.state[key] = deserializedValue;
-      changed = true;
-    }
-  }, this);
-  if (changed) {
-    provider.callback(state);
-  }
-};
-
-
-/**
- * Call the callback for each registered provider.
- * @param {function(this:Store, Object)} callback Callback.
- */
-Store.prototype._forEachProvider = function(callback) {
-  for (var i = 0, ii = this._providers.length; i < ii; ++i) {
-    callback.call(this, this._providers[i]);
-  }
-};
-
-
-/**
- * Update the store's values, notifying providers as necessary.
- * @param {Object} values New values.
- */
-Store.prototype.update = function(values) {
-  this._values = values;
-  setTimeout(function() {
-    this._forEachProvider(this._notifyProvider);
-  }.bind(this), 0);
+    state[key] = deserializedValue;
+  });
+  provider.callback(state);
 };

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,4 +1,6 @@
 var Schema = require('./schema').Schema;
+var util = require('./util');
+var serializers = require('./serializers');
 
 
 /**
@@ -126,4 +128,31 @@ Store.prototype._initializeProvider = function(provider) {
     state[key] = deserializedValue;
   });
   provider.callback(state);
+};
+
+
+/**
+ * Serialize values with provider serializers where available.
+ * @param {Object} values Values to be serialized.
+ * @return {Object} The serialized values.
+ */
+Store.prototype.serialize = function(values) {
+  var serialized = {};
+  for (var i = 0, ii = this._providers.length; i < ii; ++i) {
+    var provider = this._providers[i];
+    provider.schema.forEachKey(function(key, prefixed) {
+      if (prefixed in values) {
+        serialized[prefixed] = provider.schema.serialize(key, values[prefixed], values);
+      }
+    });
+  }
+  for (var key in values) {
+    if (!(key in serialized)) {
+      var value = values[key];
+      var type = util.typeOf(value);
+      var serializer = serializers.get(type);
+      serialized[key] = serializer(value);
+    }
+  }
+  return serialized;
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,20 +25,6 @@ exports.typeOf = function typeOf(value) {
 
 
 /**
- * Copy properties from one object to another.
- * @param {Object} dest The destination object.
- * @param {Object} source The source object.
- * @return {Object} The destination object.
- */
-exports.extend = function(dest, source) {
-  for (var key in source) {
-    dest[key] = source[key];
-  }
-  return dest;
-};
-
-
-/**
  * Generate an array of alternating name, value from an object's properties.
  * @param {Object} object The object to zip.
  * @return {Array} The array of name, value [, name, value]*.
@@ -67,4 +53,3 @@ exports.unzip = function(array) {
   }
   return object;
 };
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hashed",
-  "version": "1.2.0",
+  "version": "2.0.0-beta.1",
   "description": "Serialize state from multiple providers using location.hash",
   "homepage": "https://github.com/tschaub/hashed",
   "author": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "start": "watchy --watch package.json,lib,test -- npm test",
     "pretest": "eslint lib test",
     "test": "lab -t 100 test",
+    "test-debug": "node-debug lab --ignore window,document,regeneratorRuntime,jQuery,_babelPolyfill,core,Reflect",
     "prepublish": "in-publish && make || in-install"
   },
   "main": "lib/index.js",

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The default serializers and deserializers work for primitive state values (strin
 // you don't want JSON serialization in the URL.
 var config = {
   colors: {
-    init: [] // no colors by default
+    default: [] // no colors by default
     serialize: function(colors) {
       // Instead of JSON, you want comma delimited values.
       // Note that if you expect strings that should be encoded,
@@ -94,7 +94,7 @@ The `register` function takes two arguments:
   };
   ```
 
-  If you don't want to use the build-in functions for serializing and deserializing values, use an object with `init`, `serialize`, and `deserialize` properties.  The `init` value represents the default value (if none is present in the URL).  The `serialize` function is called with your state value and returns a string for the URL.  The `deserialize` function is called with a string and returns the value for your state.
+  If you don't want to use the build-in functions for serializing and deserializing values, use an object with `default`, `serialize`, and `deserialize` properties.  The `default` value represents the default value (if none is present in the URL).  The `serialize` function is called with your state value and returns a string for the URL.  The `deserialize` function is called with a string and returns the value for your state.
 
  * **listener** - `function(Object)` A function that is called when the URL hash is updated.  The object properties represent new state values.  The object will not include property values that have not changed.
 

--- a/test/lib/field.test.js
+++ b/test/lib/field.test.js
@@ -35,41 +35,41 @@ lab.experiment('field', function() {
         done();
       });
 
-      lab.test('creates a field from an object with init', function(done) {
-        var field = new Field({init: 42});
+      lab.test('creates a field from an object with default', function(done) {
+        var field = new Field({default: 42});
         expect(field).to.be.an.instanceof(Field);
         done();
       });
 
-      lab.test('throws for unsupported init (RegExp)', function(done) {
+      lab.test('throws for unsupported default (RegExp)', function(done) {
         var call = function() {
-          return new Field({init: /foo/});
+          return new Field({default: /foo/});
         };
         expect(call).to.throw('Unable to serialize type: regexp');
         done();
       });
 
-      lab.test('throws for unsupported init (null)', function(done) {
+      lab.test('throws for unsupported default (null)', function(done) {
         var call = function() {
-          return new Field({init: null});
+          return new Field({default: null});
         };
         expect(call).to.throw('Unable to serialize type: null');
         done();
       });
 
-      lab.test('throws for unsupported init (undefined)', function(done) {
+      lab.test('throws for unsupported default (undefined)', function(done) {
         var call = function() {
-          return new Field({init: undefined});
+          return new Field({default: undefined});
         };
         expect(call).to.throw('Unable to serialize type: undefined');
         done();
       });
 
-      lab.test('throws for an object without init', function(done) {
+      lab.test('throws for an object without default', function(done) {
         var call = function() {
           return new Field({foo: 'bar'});
         };
-        expect(call).to.throw('Missing init');
+        expect(call).to.throw('Missing default');
         done();
       });
 
@@ -77,48 +77,40 @@ lab.experiment('field', function() {
 
     lab.experiment('#serialize()', function() {
 
-      lab.test('serializes strings with init string', function(done) {
-        var field = new Field({init: 'foo'});
+      lab.test('serializes strings with default string', function(done) {
+        var field = new Field({default: 'foo'});
         expect(field.serialize('bar')).to.equal('bar');
         expect(field.serialize('')).to.equal('');
         done();
       });
 
-      lab.test('serializes numbers with init number', function(done) {
-        var field = new Field({init: 42});
+      lab.test('serializes numbers with default number', function(done) {
+        var field = new Field({default: 42});
         expect(field.serialize(100)).to.equal('100');
         expect(field.serialize(0)).to.equal('0');
         done();
       });
 
-      lab.test('serializes dates with init date', function(done) {
-        var field = new Field({init: new Date()});
+      lab.test('serializes dates with default date', function(done) {
+        var field = new Field({default: new Date()});
         var then = '2014-06-09T23:57:12.588Z';
         expect(dec(field.serialize(new Date(then)))).to.equal(then);
         done();
       });
 
-      lab.test('serializes arrays with init array', function(done) {
-        var field = new Field({init: [42, 'foo']});
+      lab.test('serializes arrays with default array', function(done) {
+        var field = new Field({default: [42, 'foo']});
         var array = ['foo', 42];
         var json = dec(field.serialize(array));
         expect(JSON.parse(json)).to.deep.equal(array);
         done();
       });
 
-      lab.test('serializes objects with init object', function(done) {
-        var field = new Field({init: {foo: 'bar'}});
+      lab.test('serializes objects with default object', function(done) {
+        var field = new Field({default: {foo: 'bar'}});
         var obj = {baz: 'bam'};
         var json = dec(field.serialize(obj));
         expect(JSON.parse(json)).to.deep.equal(obj);
-        done();
-      });
-
-      lab.test('serializes strings with init function (string)', function(done) {
-        var field = new Field({init: function() {
-          return 'foo';
-        }});
-        expect(field.serialize('bar')).to.equal('bar');
         done();
       });
 
@@ -126,7 +118,7 @@ lab.experiment('field', function() {
         var serialize = function(value) {
           return value + 'foo';
         };
-        var field = new Field({init: 42, serialize: serialize});
+        var field = new Field({default: 42, serialize: serialize});
         expect(field.serialize('10')).to.equal('10foo');
         done();
       });
@@ -135,21 +127,21 @@ lab.experiment('field', function() {
 
     lab.experiment('#deserialize()', function() {
 
-      lab.test('deserializes strings with init string', function(done) {
-        var field = new Field({init: 'foo'});
+      lab.test('deserializes strings with default string', function(done) {
+        var field = new Field({default: 'foo'});
         expect(field.deserialize('bar')).to.equal('bar');
         done();
       });
 
-      lab.test('serializes numbers with init number', function(done) {
-        var field = new Field({init: 42});
+      lab.test('serializes numbers with default number', function(done) {
+        var field = new Field({default: 42});
         expect(field.deserialize('100')).to.equal(100);
         expect(field.deserialize('0')).to.equal(0);
         done();
       });
 
-      lab.test('deserializes date with init date', function(done) {
-        var field = new Field({init: new Date()});
+      lab.test('deserializes date with default date', function(done) {
+        var field = new Field({default: new Date()});
         expect(field).to.be.an.instanceof(Field);
         var then = '2014-06-09T23:57:12.588Z';
         var date = field.deserialize(then);
@@ -157,8 +149,8 @@ lab.experiment('field', function() {
         done();
       });
 
-      lab.test('deserializes arrays with init array', function(done) {
-        var field = new Field({init: [42, 'foo']});
+      lab.test('deserializes arrays with default array', function(done) {
+        var field = new Field({default: [42, 'foo']});
         expect(field).to.be.an.instanceof(Field);
         var array = ['foo', 42];
         var json = JSON.stringify(array);
@@ -166,8 +158,8 @@ lab.experiment('field', function() {
         done();
       });
 
-      lab.test('deserializes objects with init object', function(done) {
-        var field = new Field({init: {foo: 'bar'}});
+      lab.test('deserializes objects with default object', function(done) {
+        var field = new Field({default: {foo: 'bar'}});
         expect(field).to.be.an.instanceof(Field);
         var obj = {baz: 'bam'};
         var json = JSON.stringify(obj);
@@ -175,19 +167,11 @@ lab.experiment('field', function() {
         done();
       });
 
-      lab.test('deserializes strings with init function (string)', function(done) {
-        var field = new Field({init: function() {
-          return 'foo';
-        }});
-        expect(field.deserialize('bar')).to.equal('bar');
-        done();
-      });
-
       lab.test('deserializes with deserialize function', function(done) {
         var deserialize = function(value) {
           return value + 'foo';
         };
-        var field = new Field({init: 42, deserialize: deserialize});
+        var field = new Field({default: 42, deserialize: deserialize});
         expect(field.deserialize(10)).to.equal('10foo');
         done();
       });

--- a/test/lib/hash.test.js
+++ b/test/lib/hash.test.js
@@ -22,7 +22,7 @@ lab.experiment('hash', function() {
       var values = {};
       var loc = {};
       hash.set(values, loc);
-      expect(loc.hash).to.be.undefined();
+      expect(loc.hash).to.equal('');
       done();
     });
 
@@ -50,6 +50,16 @@ lab.experiment('hash', function() {
 
       var values = hash.get(loc);
       expect(Object.keys(values)).to.have.length(0);
+      done();
+    });
+
+  });
+
+  lab.experiment('serialize()', function() {
+
+    lab.test('returns a string for the hash', function(done) {
+      var str = hash.serialize({foo: 'bar'});
+      expect(str).to.equal('#/foo/bar');
       done();
     });
 

--- a/test/lib/hash.test.js
+++ b/test/lib/hash.test.js
@@ -1,39 +1,11 @@
 var lab = exports.lab = require('lab').script();
 var expect = require('code').expect;
 
-var Store = require('../../lib/store').Store;
 var hash = require('../../lib/hash');
 
 lab.experiment('hash', function() {
 
-  lab.afterEach(function(done) {
-    hash.reset();
-    done();
-  });
-
-  lab.experiment('pluck()', function() {
-
-    lab.test('returns a subset of key/value pairs from a hash', function(done) {
-      var loc = {
-        hash: '#/foo/bar/num/42/bam/chicken'
-      };
-
-      expect(hash.pluck(loc, ['foo', 'bam'])).to.equal('#/foo/bar/bam/chicken');
-      done();
-    });
-
-    lab.test('silently disregards missing values', function(done) {
-      var loc = {
-        hash: '#/foo/bar/num/42'
-      };
-
-      expect(hash.pluck(loc, ['foo', 'bam'])).to.equal('#/foo/bar');
-      done();
-    });
-
-  });
-
-  lab.experiment('updateHash()', function() {
+  lab.experiment('set()', function() {
 
     lab.test('serializes values for the hash', function(done) {
       var values = {
@@ -41,7 +13,7 @@ lab.experiment('hash', function() {
         num: '42'
       };
       var loc = {};
-      hash.updateHash(values, loc);
+      hash.set(values, loc);
       expect(loc.hash).to.equal('#/foo/bar/num/42');
       done();
     });
@@ -49,93 +21,35 @@ lab.experiment('hash', function() {
     lab.test('does nothing for an empty object', function(done) {
       var values = {};
       var loc = {};
-      hash.updateHash(values, loc);
+      hash.set(values, loc);
       expect(loc.hash).to.be.undefined();
       done();
     });
 
   });
 
-  lab.experiment('updateStore()', function() {
-    var noop = function() {};
+  lab.experiment('get()', function() {
 
-    lab.test('calls store.update() with values from the hash', function(done) {
-      var log = [];
-      var store = new Store(noop);
-      store.update = function() {
-        log.push(arguments);
-      };
-
+    lab.test('returns values from the hash', function(done) {
       var loc = {
         hash: '#/foo/bar/num/42'
       };
 
-      hash.updateStore(loc, store);
-      expect(log).to.have.length(1);
-      var args = log[0];
-      expect(args).to.have.length(1);
-      expect(args[0]).to.deep.equal({
+      var values = hash.get(loc);
+      expect(values).to.deep.equal({
         foo: 'bar',
         num: '42'
       });
       done();
     });
 
-    lab.test('calls update with an empty object for no hash', function(done) {
-      var log = [];
-      var store = new Store(noop);
-      store.update = function() {
-        log.push(arguments);
-      };
-
+    lab.test('returns an empty object for no hash', function(done) {
       var loc = {
         hash: ''
       };
 
-      hash.updateStore(loc, store);
-      expect(log).to.have.length(1);
-      var args = log[0];
-      expect(args).to.have.length(1);
-      expect(Object.keys(args[0])).to.have.length(0);
-      done();
-    });
-
-    lab.test('does not call store.update() for values from updateHash()', function(done) {
-      var log = [];
-      var store = new Store(noop);
-      store.update = function() {
-        log.push(arguments);
-      };
-
-      var loc = {};
-
-      hash.updateHash({foo: 'bar'}, loc);
-      hash.updateStore(loc, store);
-
-      expect(log).to.have.length(0);
-      done();
-    });
-
-    lab.test('only calls store.update() for externally changed values', function(done) {
-      var log = [];
-      var store = new Store(noop);
-      store.update = function() {
-        log.push(arguments);
-      };
-
-
-      hash.updateHash({foo: 'bar'}, {});
-      hash.updateHash({num: 42}, {});
-
-      hash.updateStore({hash: '#/foo/bar'}, store);
-      expect(log).to.have.length(0);
-
-      hash.updateStore({hash: '#/num/42'}, store);
-      expect(log).to.have.length(0);
-
-      hash.updateStore({hash: '#/baz/bam'}, store);
-      expect(log).to.have.length(1);
-      expect(log[0][0]).to.deep.equal({baz: 'bam'});
+      var values = hash.get(loc);
+      expect(Object.keys(values)).to.have.length(0);
       done();
     });
 

--- a/test/lib/schema.test.js
+++ b/test/lib/schema.test.js
@@ -39,7 +39,7 @@ lab.experiment('schema', function() {
         var calls = [];
         var schema = new Schema({
           custom: {
-            init: 10,
+            default: 10,
             serialize: function(value, s) {
               calls.push([value, s]);
               return String(value);
@@ -113,20 +113,8 @@ lab.experiment('schema', function() {
         done();
       });
 
-      lab.test('gets the default given init value', function(done) {
-        var schema = new Schema({foo: {init: 'bar'}});
-        expect(schema.getDefault('foo')).to.equal('bar');
-        done();
-      });
-
-      lab.test('gets the default given init function', function(done) {
-        var schema = new Schema({
-          foo: {
-            init: function() {
-              return 'bar';
-            }
-          }
-        });
+      lab.test('gets the default value given an object with default', function(done) {
+        var schema = new Schema({foo: {default: 'bar'}});
         expect(schema.getDefault('foo')).to.equal('bar');
         done();
       });

--- a/test/lib/store.test.js
+++ b/test/lib/store.test.js
@@ -257,4 +257,37 @@ lab.experiment('store', function() {
 
   });
 
+  lab.experiment('#serialize()', function() {
+
+    lab.test('it uses default serializers', function(done) {
+      var store = new Store({}, function() {});
+
+      var serialized = store.serialize({foo: 'bar', num: 42});
+      expect(serialized).to.deep.equal({foo: 'bar', num: '42'});
+      done();
+    });
+
+    lab.test('it uses serializer from registered provider if available', function(done) {
+      var store = new Store({}, function() {});
+
+      store.register({
+        foo: {
+          default: 'bar',
+          serialize: function(value) {
+            return value.split('').reverse().join('');
+          },
+          deserialize: function(str) {
+            return str.split('').reverse().join('');
+          }
+        },
+        bam: 'baz'
+      }, function() {});
+
+      var serialized = store.serialize({foo: 'bar', num: 42});
+      expect(serialized).to.deep.equal({foo: 'rab', num: '42'});
+      done();
+    });
+
+  });
+
 });

--- a/test/lib/store.test.js
+++ b/test/lib/store.test.js
@@ -101,6 +101,42 @@ lab.experiment('store', function() {
         }, 5);
       });
 
+      lab.test('calls callback with all values when one is updated', function(done) {
+        var calls = [];
+        var store = new Store({foo: 'bar', num: '41'}, function(values) {
+          calls.push(values);
+        });
+
+        var update = store.register({foo: 'bam', num: 42}, noop);
+
+        update({num: 43});
+        expect(calls).to.have.length(0);
+
+        setTimeout(function() {
+          expect(calls).to.have.length(1);
+          expect(calls[0]).to.deep.equal({foo: 'bar', num: '43'});
+
+          done();
+        }, 5);
+      });
+
+      lab.test('does not call callback if values do not change', function(done) {
+        var calls = [];
+        var store = new Store({foo: 'bar'}, function(values) {
+          calls.push(values);
+        });
+
+        var update = store.register({foo: 'bam'}, noop);
+
+        update({foo: 'bar'});
+        expect(calls).to.have.length(0);
+
+        setTimeout(function() {
+          expect(calls).to.have.length(0);
+          done();
+        }, 5);
+      });
+
       lab.test('debounces callback calls', function(done) {
         var calls = [];
         var store = new Store({}, function(values) {

--- a/test/lib/util.test.js
+++ b/test/lib/util.test.js
@@ -62,35 +62,6 @@ lab.experiment('util', function() {
 
   });
 
-  lab.experiment('extend()', function() {
-    var extend = util.extend;
-
-    lab.test('copies properties from source to dest', function(done) {
-      var source = {foo: 'bar'};
-      var dest = {};
-      extend(dest, source);
-      expect(dest.foo).to.equal('bar');
-      done();
-    });
-
-    lab.test('overwrites existing dest properties', function(done) {
-      var source = {foo: 'bar'};
-      var dest = {foo: 'bam'};
-      extend(dest, source);
-      expect(dest.foo).to.equal('bar');
-      done();
-    });
-
-    lab.test('returns dest object', function(done) {
-      var source = {foo: 'bar'};
-      var dest = {foo: 'bam'};
-      var got = extend(dest, source);
-      expect(got).to.equal(dest);
-      done();
-    });
-
-  });
-
   lab.experiment('zip()', function() {
 
     lab.test('creates an array from an object', function(done) {


### PR DESCRIPTION
This includes the following breaking changes:

 * The callback provided to `hashed.register()` is called immediately with initial values.  These values are deserialized from the `location.hash`.  The defaults from the first argument are used when hash values are absent.

 * The callback provided to `hashed.register()` is only called once, synchronously, and is not called on future `hashchange` events.

 * Defaults are provided with a `default` property in the schema passed to `hashed.register()` (previously, this was named `init`).  The default values are provided to the passed callback if other values are not present in the hash.

 * The `hashed.pluck()` function is gone.
