### PR TITLE
Work around lack of Object.assign()

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,4 +1,5 @@
 var Field = require('./field').Field;
+var util = require('./util');
 
 
 /**
@@ -7,7 +8,7 @@ var Field = require('./field').Field;
  * @constructor
  */
 var Schema = exports.Schema = function(config) {
-  config = Object.assign({}, config);
+  config = util.extend({}, config);
   var fields = {};
   var prefix;
   if ('_' in config) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -100,7 +100,7 @@ Store.prototype.register = function(config, callback) {
       }
     });
     if (changed) {
-      Object.assign(this._values, serialized);
+      util.extend(this._values, serialized);
       this._scheduleCallback();
     }
   }.bind(this);

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,6 +25,20 @@ exports.typeOf = function typeOf(value) {
 
 
 /**
+ * Copy properties from one object to another.
+ * @param {Object} dest The destination object.
+ * @param {Object} source The source object.
+ * @return {Object} The destination object.
+ */
+exports.extend = function(dest, source) {
+  for (var key in source) {
+    dest[key] = source[key];
+  }
+  return dest;
+};
+
+
+/**
  * Generate an array of alternating name, value from an object's properties.
  * @param {Object} object The object to zip.
  * @return {Array} The array of name, value [, name, value]*.

--- a/test/lib/util.test.js
+++ b/test/lib/util.test.js
@@ -62,6 +62,35 @@ lab.experiment('util', function() {
 
   });
 
+  lab.experiment('extend()', function() {
+    var extend = util.extend;
+
+    lab.test('copies properties from source to dest', function(done) {
+      var source = {foo: 'bar'};
+      var dest = {};
+      extend(dest, source);
+      expect(dest.foo).to.equal('bar');
+      done();
+    });
+
+    lab.test('overwrites existing dest properties', function(done) {
+      var source = {foo: 'bar'};
+      var dest = {foo: 'bam'};
+      extend(dest, source);
+      expect(dest.foo).to.equal('bar');
+      done();
+    });
+
+    lab.test('returns dest object', function(done) {
+      var source = {foo: 'bar'};
+      var dest = {foo: 'bam'};
+      var got = extend(dest, source);
+      expect(got).to.equal(dest);
+      done();
+    });
+
+  });
+
   lab.experiment('zip()', function() {
 
     lab.test('creates an array from an object', function(done) {


### PR DESCRIPTION
This brings back the cheepo `util.extend()` function so things work where `Object.assign()` is absent (IE 11).