### PR TITLE
Guard against callbacks that unregister providers

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -41,8 +41,9 @@ Store.prototype.update = function(values) {
 Store.prototype._debouncedUpdate = function(newValues) {
   this._updateTimer = null;
   var values = this._values;
-  for (var i = 0, ii = this._providers.length; i < ii; ++i) {
-    var provider = this._providers[i];
+  var providers = this._providers.slice();  // callbacks may unregister providers
+  for (var i = providers.length - 1; i >= 0; --i) {
+    var provider = providers[i];
     var schema = provider.schema;
     var changed = false;
     var state = {};
@@ -68,7 +69,7 @@ Store.prototype._debouncedUpdate = function(newValues) {
       }
       state[key] = deserialized;
     });
-    if (changed) {
+    if (changed && this._providers.indexOf(provider) >= 0) {
       provider.callback(state);
     }
   }

--- a/test/lib/store.test.js
+++ b/test/lib/store.test.js
@@ -176,6 +176,52 @@ lab.experiment('store', function() {
         }, 5);
       });
 
+      lab.test('calls most recently registered provider first', function(done) {
+        var store = new Store({}, noop);
+        var log = [];
+        store.register({foo: 'bar'}, function(values) {
+          log.push('first');
+        });
+        store.register({num: 42}, function(values) {
+          log.push('second');
+        });
+        log.length = 0;
+
+        store.update({num: '43', foo: 'bam'});
+
+        setTimeout(function() {
+          expect(log).to.equal(['second', 'first']);
+          done();
+        }, 5);
+      });
+
+      lab.test('works if callbacks unregister providers', function(done) {
+        var store = new Store({}, noop);
+        var log = [];
+
+        var unregister = false;
+        function first() {
+          log.push('first');
+        }
+        function second() {
+          log.push('second');
+          if (unregister) {
+            store.unregister(first);
+          }
+        }
+        store.register({foo: 'bar'}, first);
+        store.register({num: 42}, second);
+        log.length = 0;
+
+        unregister = true;
+        store.update({num: '43', foo: 'bam'});
+
+        setTimeout(function() {
+          expect(log).to.equal(['second']);
+          done();
+        }, 5);
+      });
+
     });
 
     lab.experiment('#register()', function() {


### PR DESCRIPTION
This makes it so things don't fail if a callback ends up unregistering a provider.