### PR TITLE
Only call providers with updated values

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -55,19 +55,18 @@ Store.prototype._debouncedUpdate = function(newValues) {
         if (values[prefixed] !== serializedDefault) {
           changed = true;
           values[prefixed] = serializedDefault;
+          state[key] = deserialized;
         }
       } else if (values[prefixed] !== newValues[prefixed]) {
         try {
           deserialized = schema.deserialize(key, newValues[prefixed]);
           values[prefixed] = newValues[prefixed];
+          state[key] = deserialized;
           changed = true;
         } catch (err) {
-          deserialized = schema.deserialize(key, values[prefixed]);
+          // invalid value, pass
         }
-      } else {
-        deserialized = schema.deserialize(key, values[prefixed]);
       }
-      state[key] = deserialized;
     });
     if (changed && this._providers.indexOf(provider) >= 0) {
       provider.callback(state);

--- a/test/lib/store.test.js
+++ b/test/lib/store.test.js
@@ -72,7 +72,7 @@ lab.experiment('store', function() {
         }, 5);
       });
 
-      lab.test('calls callback with all values even if only one changed', function(done) {
+      lab.test('only calls callback with updated values', function(done) {
         var store = new Store({}, noop);
         var log = [];
         store.register({foo: 'bar', num: 42}, function(values) {
@@ -81,10 +81,10 @@ lab.experiment('store', function() {
         expect(log).to.equal([{foo: 'bar', num: 42}]);
         log.length = 0;
 
-        store.update({num: '63'});
+        store.update({num: '63', foo: 'bar'});
 
         setTimeout(function() {
-          expect(log).to.equal([{foo: 'bar', num: 63}]);
+          expect(log).to.equal([{num: 63}]);
           done();
         }, 5);
       });
@@ -119,7 +119,7 @@ lab.experiment('store', function() {
         store.update({foo: 'bam'});
 
         setTimeout(function() {
-          expect(log).to.equal([{foo: 'bam', num: 42}]);
+          expect(log).to.equal([{foo: 'bam'}]);
           done();
         }, 5);
       });
@@ -159,7 +159,7 @@ lab.experiment('store', function() {
         }, 5);
       });
 
-      lab.test('calls callback for if only some of the values are garbage', function(done) {
+      lab.test('calls callback with valid values if some of the values are garbage', function(done) {
         var store = new Store({}, noop);
         var log = [];
         store.register({foo: 'bar', num: 42}, function(values) {
@@ -171,7 +171,7 @@ lab.experiment('store', function() {
         store.update({num: 'garbage', foo: 'bam'});
 
         setTimeout(function() {
-          expect(log).to.equal([{foo: 'bam', num: 42}]);
+          expect(log).to.equal([{foo: 'bam'}]);
           done();
         }, 5);
       });


### PR DESCRIPTION
Instead of calling providers with all values when any one is updated, this makes it so providers are only called with changed values.  This means that provider callbacks must be prepared to handle partial states. 