### PR TITLE
Listen for popstate instead of hashchange

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,23 +1,14 @@
 var util = require('./util');
 
 /**
- * Update the hash with the provided string values.
- * @param {Object} values String values by key.
- * @param {Object} loc The location object whose hash property will be set.
+ * Get values from a hash string.
+ * @param {string} hash The hash string (e.g. '#/foo/bar').
+ * @return {Object} The string values (e.g. {foo: 'bar'}).
  */
-function set(values, loc) {
-  loc.hash = serialize(values);
-}
-
-/**
- * Get the current string values.
- * @param {Object} loc The location with hash values.
- * @return {Object} The string values.
- */
-function get(loc) {
+function deserialize(hash) {
   var zipped;
-  if (loc.hash.length > 2) {
-    var path = loc.hash.substring(2);
+  if (hash.length > 2) {
+    var path = hash.substring(2);
     zipped = path.split('/');
   } else {
     zipped = [];
@@ -39,6 +30,5 @@ function serialize(values) {
   return path;
 }
 
-exports.get = get;
-exports.set = set;
+exports.deserialize = deserialize;
 exports.serialize = serialize;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,22 +5,22 @@ var store;
 
 function reset() {
   if (store) {
-    window.removeEventListener('hashchange', update);
+    window.removeEventListener('popstate', update);
   }
-  window.addEventListener('hashchange', update);
-  store = new Store(hash.get(location), function(values, defaults) {
+  window.addEventListener('popstate', update);
+  store = new Store(hash.deserialize(location.hash), function(values, defaults) {
     var nonDefaults = {};
     for (var key in values) {
       if (values[key] !== defaults[key]) {
         nonDefaults[key] = values[key];
       }
     }
-    hash.set(nonDefaults, location);
+    history.pushState(values, '', hash.serialize(nonDefaults));
   });
 }
 
 function update() {
-  store.update(hash.get(location));
+  store.update(hash.deserialize(location.hash));
 }
 
 /**

--- a/test/lib/hash.test.js
+++ b/test/lib/hash.test.js
@@ -5,37 +5,14 @@ var hash = require('../../lib/hash');
 
 lab.experiment('hash', function() {
 
-  lab.experiment('set()', function() {
-
-    lab.test('serializes values for the hash', function(done) {
-      var values = {
-        foo: 'bar',
-        num: '42'
-      };
-      var loc = {};
-      hash.set(values, loc);
-      expect(loc.hash).to.equal('#/foo/bar/num/42');
-      done();
-    });
-
-    lab.test('does nothing for an empty object', function(done) {
-      var values = {};
-      var loc = {};
-      hash.set(values, loc);
-      expect(loc.hash).to.equal('');
-      done();
-    });
-
-  });
-
-  lab.experiment('get()', function() {
+  lab.experiment('deserialize()', function() {
 
     lab.test('returns values from the hash', function(done) {
       var loc = {
         hash: '#/foo/bar/num/42'
       };
 
-      var values = hash.get(loc);
+      var values = hash.deserialize(loc.hash);
       expect(values).to.equal({
         foo: 'bar',
         num: '42'
@@ -48,7 +25,7 @@ lab.experiment('hash', function() {
         hash: ''
       };
 
-      var values = hash.get(loc);
+      var values = hash.deserialize(loc.hash);
       expect(Object.keys(values)).to.have.length(0);
       done();
     });
@@ -60,6 +37,12 @@ lab.experiment('hash', function() {
     lab.test('returns a string for the hash', function(done) {
       var str = hash.serialize({foo: 'bar'});
       expect(str).to.equal('#/foo/bar');
+      done();
+    });
+
+    lab.test('returns an empty string an empty object', function(done) {
+      var str = hash.serialize({});
+      expect(str).to.equal('');
       done();
     });
 


### PR DESCRIPTION
It has been troublesome to rely on `hashchange` events.  Under some conditions, multiple updates from providers would result in callbacks being called with stale state.  This branch makes it so updates from providers result in `history.pushState()` calls, and then we listen for `popstate` when the user navigates through history.
