### PR TITLE
Ensure any existing hash is cleared

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -22,7 +22,7 @@ function deserialize(hash) {
  * @return {string} The hash string.
  */
 function serialize(values) {
-  var path = '';
+  var path = '#';
   var parts = util.zip(values);
   if (parts.length > 0) {
     path = '#/' + parts.join('/');

--- a/test/lib/hash.test.js
+++ b/test/lib/hash.test.js
@@ -40,9 +40,9 @@ lab.experiment('hash', function() {
       done();
     });
 
-    lab.test('returns an empty string an empty object', function(done) {
+    lab.test('returns # for an empty object', function(done) {
       var str = hash.serialize({});
-      expect(str).to.equal('');
+      expect(str).to.equal('#');
       done();
     });
 


### PR DESCRIPTION
When changing back to the default state, this makes it so any existing hash is cleared.